### PR TITLE
shapes: subject_map: fix misleading message

### DIFF
--- a/shapes/subject_map.ttl
+++ b/shapes/subject_map.ttl
@@ -18,7 +18,8 @@
     Represents a Subject Map.
     """ ;
     sh:message """
-    Subject Map must generate an IRI representing the subject of an RDF triple.
+    Subject Map must generate a resource representing the subject of
+    an RDF triple.
     """ ;
 
     sh:and (


### PR DESCRIPTION
Message is misleading. 'IRI' should be replaced by 'resource'. Fixes https://github.com/kg-construct/rml-core/issues/109