### PR TITLE
fix wrong references for issue 143

### DIFF
--- a/test-cases/RMLTC0007h-JSON/mapping.ttl
+++ b/test-cases/RMLTC0007h-JSON/mapping.ttl
@@ -12,13 +12,13 @@
     ];
   rml:predicateObjectMap [
       rml:objectMap [
-          rml:reference "$.Name"
+          rml:reference "$.FirstName"
         ];
       rml:predicate foaf:name
     ];
   rml:subjectMap [
       rml:graphMap [
-          rml:reference "$.Name";
+          rml:reference "$.ID";
           rml:termType rml:Literal
         ];
       rml:template "http://example.com/Student/{$.ID}/{$.FirstName}"


### PR DESCRIPTION
Fixes #143. Test case 7h contained wrong references that would create an error without a wrongly defined Graph Map. 