### PR TITLE
19b expects an error now

### DIFF
--- a/test-cases/RMLTC0019b-JSON/README.md
+++ b/test-cases/RMLTC0019b-JSON/README.md
@@ -6,7 +6,7 @@
 
 **Default Base IRI**: http://example.com/
 
-**Error expected?** No
+**Error expected?** Yes
 
 **Input**
 ```

--- a/test-cases/make-metadata.py
+++ b/test-cases/make-metadata.py
@@ -92,10 +92,12 @@ def main(spec: str):
 
             # Output files
             if os.path.exists(os.path.join(testcase, 'output.nq')):
+                if os.path.getsize(os.path.join(testcase, 'output.nq')) == 0:
+                    error = 'true'
                 output1 = 'output.nq'
                 output_format1 = 'application/n-quads'
             else:
-                error = 'true';
+                error = 'true'
 
             writer.writerow([testcase, title, description, spec, mapping_file,
                              input_format1, input_format2, input_format3,


### PR DESCRIPTION
As we discussed in #199, although there is an output.ttl, if it's empty, an error is expected. This only affects test case 19b